### PR TITLE
Support for iteration shorthands

### DIFF
--- a/lib/moment-range.js
+++ b/lib/moment-range.js
@@ -40,7 +40,7 @@
     /**
       * Iterate over the date range by a given date range, executing a function
       * for each sub-range.
-      * @param {!DateRange}        range     Date range to be used for iteration.
+      * @param {!DateRange|String}        range     Date range to be used for iteration or shorthand string (shorthands: http://momentjs.com/docs/#/manipulating/add/)
       * @param {!function(Moment)} hollaback Function to execute for each sub-range.
       * @return {!boolean}
     *
@@ -48,7 +48,12 @@
 
 
     DateRange.prototype.by = function(range, hollaback) {
-      var i, l, _i;
+      var end, i, l, start, _i;
+      if (typeof range === 'string') {
+        start = moment();
+        end = moment(start).add(range, 1);
+        range = moment().range(start, end);
+      }
       l = Math.round(this / range);
       for (i = _i = 0; 0 <= l ? _i <= l : _i >= l; i = 0 <= l ? ++_i : --_i) {
         hollaback.call(this, moment(this.start.valueOf() + range.valueOf() * i));

--- a/src/moment-range.coffee
+++ b/src/moment-range.coffee
@@ -28,13 +28,17 @@ class DateRange
   ###*
     * Iterate over the date range by a given date range, executing a function
     * for each sub-range.
-    * @param {!DateRange}        range     Date range to be used for iteration.
+    * @param {!DateRange|String}        range     Date range to be used for iteration or shorthand string (shorthands: http://momentjs.com/docs/#/manipulating/add/)
     * @param {!function(Moment)} hollaback Function to execute for each sub-range.
     * @return {!boolean}
   *###
   by: (range, hollaback) ->
-    l = Math.round @ / range
+    if typeof range is 'string'
+      start = moment()
+      end = moment(start).add range, 1
+      range = moment().range start, end
 
+    l = Math.round @ / range
     for i in [0..l]
       hollaback.call @, moment(@start.valueOf() + range.valueOf() * i)
 


### PR DESCRIPTION
Enables `DateRange.prototype.by()` to accept either a `DateRange` or a [shorthand string](http://momentjs.com/docs/#/manipulating/add/) as the first argument.
#4
