### PR TITLE
Use the local node_modules coffee script binary

### DIFF
--- a/Cakefile
+++ b/Cakefile
@@ -6,7 +6,7 @@ responder = (err, stdout, stderr) ->
   console.error stderr if stderr
 
 task 'build', 'Build project from src/*.coffee to lib/*.js', ->
-  exec 'coffee --compile --output lib/ src/', responder
+  exec './node_modules/.bin/coffee --compile --output lib/ src/', responder
 
 task 'test', 'Run the test suite', ->
   exec './node_modules/.bin/mocha --compilers coffee:coffee-script --reporter spec --ui bdd --colors', responder


### PR DESCRIPTION
`cake build` was trying to use the global coffee script binary instead of the one installed by `npm install` On my machine those are now quite different versions. This just uses the local one so build and test use the same coffeescript compiler.
