### PR TITLE
make contains with date ranges an inclusive comparison

### DIFF
--- a/lib/moment-range.bare.js
+++ b/lib/moment-range.bare.js
@@ -30,7 +30,7 @@ DateRange = (function() {
 
   DateRange.prototype.contains = function(other) {
     if (other instanceof DateRange) {
-      return this.start < other.start && this.end > other.end;
+      return this.start <= other.start && this.end >= other.end;
     } else {
       return (this.start <= other && other <= this.end);
     }

--- a/lib/moment-range.js
+++ b/lib/moment-range.js
@@ -41,7 +41,7 @@ DateRange = (function() {
 
   DateRange.prototype.contains = function(other) {
     if (other instanceof DateRange) {
-      return this.start < other.start && this.end > other.end;
+      return this.start <= other.start && this.end >= other.end;
     } else {
       return (this.start <= other && other <= this.end);
     }

--- a/src/moment-range.coffee
+++ b/src/moment-range.coffee
@@ -20,7 +20,7 @@ class DateRange
   *###
   contains: (other) ->
     if other instanceof DateRange
-      @start < other.start and @end > other.end
+      @start <= other.start and @end >= other.end
     else
       @start <= other <= @end
 

--- a/test/moment-range.coffee
+++ b/test/moment-range.coffee
@@ -141,6 +141,12 @@ describe "DateRange", ->
       dr1.contains(dr2).should.be.true
       dr2.contains(dr1).should.be.false
 
+    it "should be an inclusive comparison", ->
+      dr1 = moment().range(m_1, m_4)
+      dr1.contains(m_1).should.be.true
+      dr1.contains(m_4).should.be.true
+      dr1.contains(dr1).should.be.true
+      
   describe "#overlaps()", ->
     it "should work with DateRange objects", ->
       dr_1 = moment().range(m_1, m_2)


### PR DESCRIPTION
test and fix so that r.contains(r) == true when r is a moment-range
