### PR TITLE
Handle undefined start / end for Open Ended Ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,9 +133,11 @@ You can also create open-ended ranges which go to the earliest or latest possibl
 
 ``` js
 const rangeUntil = moment.range(null, '2011-05-05');
-const rangeFrom = moment.range('2011-03-05', null);
-const rangeAllTime = moment.range(null, null);
+const rangeFrom = moment.range('2011-03-05');
+const rangeAllTime = moment.range();
 ```
+
+Note that any falsy value except 0 is treated as a missing date, resulting in an open-ended range.
 
 *Note:* Dates and moment objects both use a timestamp of 00:00:000 if none is
 provided. To ensure your range includes any timestamp for the given end date,

--- a/lib/moment-range.js
+++ b/lib/moment-range.js
@@ -35,8 +35,8 @@ export class DateRange {
       }
     }
 
-    this.start = (s == null) ? moment(-8640000000000000) : moment(s);
-    this.end = (e == null) ? moment(8640000000000000) : moment(e);
+    this.start = s || s === 0 ? moment(s) : moment(-8640000000000000);
+    this.end = e || e === 0 ? moment(e) : moment(8640000000000000);
   }
 
   adjacent(other) {

--- a/lib/moment-range.js
+++ b/lib/moment-range.js
@@ -35,8 +35,8 @@ export class DateRange {
       }
     }
 
-    this.start = (s === null) ? moment(-8640000000000000) : moment(s);
-    this.end = (e === null) ? moment(8640000000000000) : moment(e);
+    this.start = (s == null) ? moment(-8640000000000000) : moment(s);
+    this.end = (e == null) ? moment(8640000000000000) : moment(e);
   }
 
   adjacent(other) {

--- a/lib/moment-range_test.js
+++ b/lib/moment-range_test.js
@@ -103,7 +103,18 @@ describe('DateRange', function() {
 
       expect(moment.isMoment(dr.start)).to.be(true);
 
-      dr = moment.range(m1, null);
+      dr = moment.range(m1, false);
+
+      expect(moment.isMoment(dr.end)).to.be(true);
+    });
+
+    it('should allow initialization with Jan 1 1970', function() {
+      let dr = moment.range(0, 0);
+
+      expect(dr.start.year()).to.be(1970);
+      expect(dr.end.year()).to.be(1970);
+
+      dr = moment.range(m1, false);
 
       expect(moment.isMoment(dr.end)).to.be(true);
     });


### PR DESCRIPTION
`== null` catches both `undefined` and `null`

If eslint complains, you may need `eqeqeq: ["error", "always", {"null": "ignore"}]`.