### PR TITLE
intersect(): return new DateRange instances in *EVERY* case

### DIFF
--- a/lib/moment-range.js
+++ b/lib/moment-range.js
@@ -164,10 +164,10 @@ export class DateRange {
       return new this.constructor(start, oEnd);
     }
     else if ((oStart < start) && (start <= end) && (end < oEnd)) {
-      return this;
+      return new this.constructor(start, end);
     }
     else if ((start <= oStart) && (oStart <= oEnd) && (oEnd <= end)) {
-      return other;
+      return new this.constructor(oStart, oEnd);
     }
 
     return null;

--- a/lib/moment-range_test.js
+++ b/lib/moment-range_test.js
@@ -721,6 +721,7 @@ describe('DateRange', function() {
     const d6 = new Date(Date.UTC(2011, 4, 4));
     const d7 = new Date(Date.UTC(2011, 6, 6));
     const d8 = new Date(Date.UTC(2011, 8, 8));
+    const v  = Symbol();
 
     it('should work with [---{==]---} overlaps where (a=[], b={})', function() {
       const dr1 = moment.range(d5, d7);
@@ -817,6 +818,28 @@ describe('DateRange', function() {
       const dr2 = moment.range(d5, d7);
 
       expect(dr1.intersect(dr2).isSame(dr1)).to.be(true);
+    });
+
+    it('should return a new DateRange instance when the left range is included into the right one', function() {
+      const dr1 = moment.range(d5, d8);
+      const dr2 = moment.range(d6, d7);
+
+      const intersection = dr2.intersect(dr1);
+
+      intersection.start = v;
+
+      expect(dr2.start !== v).to.be(true);
+    });
+
+    it('should return a new DateRange instance when the right range is included into the left one', function() {
+      const dr1 = moment.range(d5, d8);
+      const dr2 = moment.range(d6, d7);
+
+      const intersection = dr1.intersect(dr2);
+
+      intersection.start = v;
+
+      expect(dr2.start !== v).to.be(true);
     });
   });
 

--- a/lib/moment-range_test.js
+++ b/lib/moment-range_test.js
@@ -721,7 +721,6 @@ describe('DateRange', function() {
     const d6 = new Date(Date.UTC(2011, 4, 4));
     const d7 = new Date(Date.UTC(2011, 6, 6));
     const d8 = new Date(Date.UTC(2011, 8, 8));
-    const v  = Symbol();
 
     it('should work with [---{==]---} overlaps where (a=[], b={})', function() {
       const dr1 = moment.range(d5, d7);
@@ -818,28 +817,6 @@ describe('DateRange', function() {
       const dr2 = moment.range(d5, d7);
 
       expect(dr1.intersect(dr2).isSame(dr1)).to.be(true);
-    });
-
-    it('should return a new DateRange instance when the left range is included into the right one', function() {
-      const dr1 = moment.range(d5, d8);
-      const dr2 = moment.range(d6, d7);
-
-      const intersection = dr2.intersect(dr1);
-
-      intersection.start = v;
-
-      expect(dr2.start !== v).to.be(true);
-    });
-
-    it('should return a new DateRange instance when the right range is included into the left one', function() {
-      const dr1 = moment.range(d5, d8);
-      const dr2 = moment.range(d6, d7);
-
-      const intersection = dr1.intersect(dr2);
-
-      intersection.start = v;
-
-      expect(dr2.start !== v).to.be(true);
     });
   });
 


### PR DESCRIPTION
Small inconsistency detected: sometimes intersect() creates a new range, sometimes it does not. There is no documentation that tells you when you can transform the output of the method and when you can't. With this pull request, users will be able to reuse the resulting range without creating a new instance and without mutating the source date ranges.