### PR TITLE
.contains exclusivity

### DIFF
--- a/lib/moment-range.js
+++ b/lib/moment-range.js
@@ -137,7 +137,7 @@ export class DateRange {
       oEnd = other.end.valueOf();
     }
 
-    const startInRange = (start < oStart) || ((start <= oStart) && !options.exclusive);
+    const startInRange = start <= oStart;
     const endInRange = (end > oEnd) || ((end >= oEnd) && !options.exclusive);
 
     return (startInRange && endInRange);


### PR DESCRIPTION
To be consistent with the docs, the start of the range should always be inclusive.