### PR TITLE
#175 parseZoneRange will preserve original time zones

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Fancy date ranges for [Moment.js][moment].
     - [`toDate`](#todate)
     - [`toString`](#tostring)
     - [`valueOf`](#valueof)
+    - [`parseZoneRange`](#parseZoneRange)
 - [Running Tests](#running-tests)
 - [Contributors](#contributors)
 - [License](#license)
@@ -557,6 +558,18 @@ const end   = new Date(2011, 5, 5);
 const range = moment.range(start, end);
 
 range.valueOf(); // 7945200000
+```
+
+#### `parseZoneRange`
+
+Parses an [ISO 8601 time interval][interval] into a `range` while
+preserving the time zones using `moment.parseZone`.  
+
+``` js
+const interval = '2015-01-17T09:50:04+03:00/2015-04-17T08:29:55-04:00';
+const range = moment.parseZoneRange(interval);
+
+range.toString(); // '2015-01-17T09:50:04+03:00/2015-04-17T08:29:55-04:00'
 ```
 
 ## Running Tests

--- a/README.md
+++ b/README.md
@@ -563,7 +563,7 @@ range.valueOf(); // 7945200000
 #### `parseZoneRange`
 
 Parses an [ISO 8601 time interval][interval] into a `range` while
-preserving the time zones using [moment.parseZone](parseZone).  
+preserving the time zones using [moment.parseZone][parseZone].  
 
 ``` js
 const interval = '2015-01-17T09:50:04+03:00/2015-04-17T08:29:55-04:00';

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Fancy date ranges for [Moment.js][moment].
     - [`toDate`](#todate)
     - [`toString`](#tostring)
     - [`valueOf`](#valueof)
-    - [`parseZoneRange`](#parseZoneRange)
+    - [`parseZoneRange`](#parsezonerange)
 - [Running Tests](#running-tests)
 - [Contributors](#contributors)
 - [License](#license)
@@ -563,7 +563,7 @@ range.valueOf(); // 7945200000
 #### `parseZoneRange`
 
 Parses an [ISO 8601 time interval][interval] into a `range` while
-preserving the time zones using `moment.parseZone`.  
+preserving the time zones using [moment.parseZone](parseZone).  
 
 ``` js
 const interval = '2015-01-17T09:50:04+03:00/2015-04-17T08:29:55-04:00';
@@ -629,3 +629,4 @@ moment-range is [UNLICENSED][unlicense].
 [moment]: http://momentjs.com/
 [node]: http://nodejs.org/
 [unlicense]: http://unlicense.org/
+[parseZone]: https://momentjs.com/docs/#/parsing/parse-zone/

--- a/declarations/moment.js.flow
+++ b/declarations/moment.js.flow
@@ -233,6 +233,7 @@ declare class moment$Moment {
 
   // moment-range additions
   fn: Object;
+  parseZoneRange(isoTimeInterval: string): DateRange;
   static range(interval: string): DateRange;
   static range(start: Date, end: Date): DateRange;
   static range(start: Moment, end: Moment): DateRange;

--- a/lib/moment-range.js
+++ b/lib/moment-range.js
@@ -322,8 +322,15 @@ export function extendMoment(moment) {
     return new DateRange(start, end);
   };
 
-  moment.parseZoneRange = function(iso) {
-    const momentStrings = isoSplit(iso);
+    /** Uses moment.parseZone on both the start and end of the given time interval
+     *  so calling toString on the resulting momentRange will preserve the time zones
+     *  in the original time interval.
+     *
+     * @param isoTimeInterval {string} the timeInterval to be parsed
+     * @return {DateRange} constructed using moments that will preserve the time zones
+     */
+  moment.parseZoneRange = function(isoTimeInterval) {
+    const momentStrings = isoSplit(isoTimeInterval);
     const start = moment.parseZone(momentStrings[0]);
     const end = moment.parseZone(momentStrings[1]);
     return new DateRange(start, end);

--- a/lib/moment-range.js
+++ b/lib/moment-range.js
@@ -31,7 +31,7 @@ export class DateRange {
         [s, e] = start;
       }
       else if (typeof start === 'string') {
-        [s, e] = start.split('/');
+        [s, e] = isoSplit(start);
       }
     }
 
@@ -294,6 +294,15 @@ export class DateRange {
   }
 }
 
+/** Splits the iso string into two strings.
+ *
+ * @param {string} isoString
+ * @return {string[]}
+ */
+function isoSplit(isoString) {
+  return isoString.split('/');
+}
+
 
 //-----------------------------------------------------------------------------
 // Moment Extensions
@@ -310,6 +319,13 @@ export function extendMoment(moment) {
       return new DateRange(moment(m).startOf(start), moment(m).endOf(start));
     }
 
+    return new DateRange(start, end);
+  };
+
+  moment.parseZoneRange = function(iso) {
+    const momentStrings = isoSplit(iso);
+    const start = moment.parseZone(momentStrings[0]);
+    const end = moment.parseZone(momentStrings[1]);
     return new DateRange(start, end);
   };
 

--- a/lib/moment-range_test.js
+++ b/lib/moment-range_test.js
@@ -91,6 +91,14 @@ describe('DateRange', function() {
       expect(moment.utc(end).isSame(dr.end)).to.be(true);
     });
 
+    it('should allow moments to keep given time zone', function() {
+      const start = '2015-01-17T09:50:04+03:00';
+      const end   = '2015-04-17T08:29:55-04:00';
+      const timeInterval = start + '/' + end;
+      const range = moment.parseZoneRange(timeInterval);
+      expect(range.toString()).equal(timeInterval);
+    });
+
     it('should allow initialization with an array', function() {
       const dr = moment.range([m1, m2]);
 


### PR DESCRIPTION
created parseZoneRange to match the parseZone, but for the date range.
extracted the splitting of the timeInterval string into a separate method for re-use.
added a test to demonstrate the new method works