### PR TITLE
Add postinstall build

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
   },
   "files": [
     "dist/",
-    "lib/"
+    "lib/",
+    "webpack.config.js"
   ],
   "scripts": {
     "build": "webpack",

--- a/package.json
+++ b/package.json
@@ -41,9 +41,9 @@
     "doctoc": "doctoc README.md --github",
     "flow": "flow",
     "lint": "eslint ./lib/",
-    "prepublish": "npm run build; cp ./declarations/moment-range.js.flow ./dist",
+    "prepublishOnly": "npm run build; cp ./declarations/moment-range.js.flow ./dist",
     "preversion": "npm run flow && npm run lint && npm run test",
-    "postinstall": "postinstall-build --only-as-dependency ./dist prepublish",
+    "postinstall": "postinstall-build --only-as-dependency ./dist/",
     "test": "karma start ./karma.conf.js",
     "version": "npm run build; cp ./declarations/moment-range.js.flow ./dist"
   },

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "lint": "eslint ./lib/",
     "prepublish": "npm run build; cp ./declarations/moment-range.js.flow ./dist",
     "preversion": "npm run flow && npm run lint && npm run test",
+    "postinstall": "postinstall-build --only-as-dependency ./dist prepublish",
     "test": "karma start ./karma.conf.js",
     "version": "npm run build; cp ./declarations/moment-range.js.flow ./dist"
   },
@@ -83,6 +84,7 @@
     "url": "https://github.com/gf3/moment-range/raw/master/UNLICENSE"
   },
   "dependencies": {
-    "es6-symbol": "^3.1.0"
+    "es6-symbol": "^3.1.0",
+    "postinstall-build": "^5.0.1"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,7 +30,10 @@ module.exports = {
   resolve: {
     modules: [
       path.resolve(__dirname, './src'),
-      path.resolve(__dirname, './node_modules')
+      path.resolve(__dirname, './node_modules'),
+      // If we're using webpack in the postinstall step this package is being installed as a dependency this means
+      // that the node_modules directory we are looking for (for es6-symbol) is directly above us.
+      path.resolve(__dirname, '../')
     ]
   },
   resolveLoader: {
@@ -42,7 +45,7 @@ module.exports = {
     filename: 'moment-range.js',
     library: 'moment-range',
     libraryTarget: 'umd',
-    path: './dist/',
+    path: path.resolve(__dirname, './dist/'),
     umdNamedDefine: true
   },
   plugins: [


### PR DESCRIPTION
After adding the `isoWeek` I tried installing moment-range directly from github, this didn't work immediately. To make this work though I've shuffled the NPM scripts around, if I understand the NPM and postinstall-build documentation correctly this should't change the publish process at all.