### PR TITLE
Date range constructor automatically sorts start/end dates

### DIFF
--- a/lib/moment-range.js
+++ b/lib/moment-range.js
@@ -37,6 +37,10 @@ export class DateRange {
 
     this.start = (s === null) ? moment(-8640000000000000) : moment(s);
     this.end = (e === null) ? moment(8640000000000000) : moment(e);
+
+    if (this.end.isBefore(this.start)) {
+      [this.start, this.end] = [this.end, this.start];
+    }
   }
 
   adjacent(other) {

--- a/lib/moment-range_test.js
+++ b/lib/moment-range_test.js
@@ -131,6 +131,15 @@ describe('DateRange', function() {
       expect(r.start.isSame(quarterStart)).to.be(true);
       expect(r.end.isSame(quarterEnd)).to.be(true);
     });
+
+    it('should automatically sort the range start and end date', function() {
+      const a = moment('2005-01-01');
+      const b = moment('2008-12-20');
+      const r = moment.range(b, a);
+
+      expect(r.start.isSame(a)).to.be(true);
+      expect(r.end.isSame(b)).to.be(true);
+    });
   });
 
   describe('#adjacent', function() {


### PR DESCRIPTION
DateRanges should have start date before the end date, this is now automatically corrected in the constructor.

Should a user need a reverse range, they can easily change their application logic to remember that start/end is the opposite.