### PR TITLE
Webpack build improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 * Changed `build` script to use webpack's production settings for a more
   optimized build
+* Changed `prepublsh` script to `prepublshOnly` so the task isn't run on
+  `install`
+* Changed `prepublshOnly` and `version` scripts to use `&&` instead of `;`
 
 ## [3.1.0]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 * Changed `build` script to use webpack's production settings for a more
   optimized build
-* Changed `prepublsh` script to `prepublshOnly` so the task isn't run on
+* Changed `prepublish` script to `prepublishOnly` so the task isn't run on
   `install`
-* Changed `prepublshOnly` and `version` scripts to use `&&` instead of `;`
+* Changed `prepublishOnly` and `version` scripts to use `&&` instead of `;`
 
 ## [3.1.0]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+
+* Changed `build` script to use webpack's production settings for a more
+  optimized build
 
 ## [3.1.0]
 ### Added

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "lib/"
   ],
   "scripts": {
-    "build": "webpack",
+    "build": "webpack -p",
     "doctoc": "doctoc README.md --github",
     "flow": "flow",
     "lint": "eslint ./lib/",

--- a/package.json
+++ b/package.json
@@ -41,10 +41,10 @@
     "doctoc": "doctoc README.md --github",
     "flow": "flow",
     "lint": "eslint ./lib/",
-    "prepublish": "yarn run build; cp ./declarations/moment-range.js.flow ./dist",
+    "prepublishOnly": "yarn run build && cp ./declarations/moment-range.js.flow ./dist",
     "preversion": "yarn run flow && yarn run lint && yarn run test",
     "test": "karma start ./karma.conf.js",
-    "version": "yarn run build; cp ./declarations/moment-range.js.flow ./dist"
+    "version": "yarn run build && cp ./declarations/moment-range.js.flow ./dist"
   },
   "devDependencies": {
     "babel-core": "^6.18.2",


### PR DESCRIPTION
### Use webpack's production mode for a more optimized build
* Fixes #158
* Fixes #179
* Update `build` script to include production flag
* Findings:
    - `moment-range` source is `10kb`
    - when compiled with its deps by webpack it's `29kb`
    - when compiled with its deps by rollup it's `20kb`
    - when compiled with its deps by webpack in production mode it's `12kb`

### Change `prepublish` script to `prepublishOnly`
* Fixes #203 