### PR TITLE
Deprecate `exclusive` option of `contains()` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Deprecated
+
+* Deprecated `exclusive` option of `contains()` method in favour of new
+  `excludeStart` and `excludeEnd` options
+
 ### Added
 
 * Added Typescript defitions
 * Added Typescript config and tests
 * Added `check`, `typescript-test` npm script
+* Added `excludeStart` and `excludeEnd` to `contains()` method
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -233,30 +233,24 @@ Check to see if your range contains a date/moment. By default the start and end
 dates are included in the search. E.g.:
 
 ``` js
-const start = moment('2017-12-01');
-const end = moment('2017-12-15');
-const inside = moment('2017-12-08');
-const outside = moment('2017-12-25');
-const range = moment.range(start, out);
+const range = moment.range(a, c);
 
-range.contains(start); // true
-range.contains(end); // true
-range.contains(inside); // true
-range.contains(outside); // false
+range.contains(a); // true
+range.contains(b); // true
+range.contains(c); // true
+range.contains(d); // false
 ```
 
 You can also control whether the start or end dates should be excluded from the
 search with the `excludeStart` and `excludeEnd` options:
 
 ``` js
-const start = moment('2017-12-01');
-const end = moment('2017-12-15');
-const range  = moment.range(start, out);
+const range = moment.range(a, c);
 
-range.contains(start); // true
-range.contains(start, { excludeStart: true }); // false
-range.contains(end); // true
-range.contains(end, { excludeEnd: true; }); // false
+range.contains(a); // true
+range.contains(a, { excludeStart: true }); // false
+range.contains(c); // true
+range.contains(c, { excludeEnd: true; }); // false
 ```
 
 **DEPRECATED**: The `exclusive` options is used to indicate if the start/end of
@@ -266,9 +260,9 @@ the range should be excluded when testing for inclusion:
 true, excludeEnd: true }`
 
 ``` js
-range.contains(c) // true
-range.contains(c, { exclusive: false }) // true
-range.contains(c, { exclusive: true }) // false
+range.contains(c); // true
+range.contains(c, { exclusive: false }); // true
+range.contains(c, { exclusive: true }); // false
 ```
 
 #### Within

--- a/README.md
+++ b/README.md
@@ -227,20 +227,43 @@ const dr    = moment.range(start, end);
 dr.center(); // 1300622400000
 ```
 
-
 #### Contains
 
-Check to see if your range contains a date/moment:
+Check to see if your range contains a date/moment. By default the start and end
+dates are included in the search. E.g.:
 
 ``` js
-const range  = moment.range(a, c);
+const start = moment('2017-12-01');
+const end = moment('2017-12-15');
+const inside = moment('2017-12-08');
+const outside = moment('2017-12-25');
+const range = moment.range(start, out);
 
-range.contains(b); // true
-range.contains(d); // false
+range.contains(start); // true
+range.contains(end); // true
+range.contains(inside); // true
+range.contains(outside); // false
 ```
 
-The `exclusive` options is used to indicate if the end of the range should be
-excluded when testing for inclusion:
+You can also control whether the start or end dates should be excluded from the
+search with the `excludeStart` and `excludeEnd` options:
+
+``` js
+const start = moment('2017-12-01');
+const end = moment('2017-12-15');
+const range  = moment.range(start, out);
+
+range.contains(start); // true
+range.contains(start, { excludeStart: true }); // false
+range.contains(end); // true
+range.contains(end, { excludeEnd: true; }); // false
+```
+
+**DEPRECATED**: The `exclusive` options is used to indicate if the start/end of
+the range should be excluded when testing for inclusion:
+
+**Note**: You can obtain the same functionality by setting `{ excludeStart:
+true, excludeEnd: true }`
 
 ``` js
 range.contains(c) // true

--- a/declarations/moment-range.js.flow
+++ b/declarations/moment-range.js.flow
@@ -27,7 +27,9 @@ declare module 'moment-range' {
 
     clone(): DateRange;
 
+    // @deprecated
     contains(other: Date | DateRange | Moment, options?: { exclusive: bool; }): bool;
+    contains(other: Date | DateRange | Moment, options?: { excludeStart: bool; excludeEnd: bool; }): bool;
 
     diff(unit: ?Shorthand, rounded: ?bool): number;
 

--- a/lib/moment-range.d.ts
+++ b/lib/moment-range.d.ts
@@ -23,7 +23,9 @@ export class DateRange {
 
   clone(): DateRange;
 
+  // @deprecated
   contains(other: Date | DateRange | Moment, options?: { exclusive?: boolean; }): boolean;
+  contains(other: Date | DateRange | Moment, options?: { excludeStart?: boolean; excludeEnd?: boolean; }): boolean;
 
   diff(unit?: unitOfTime.Diff, rounded?: boolean): number;
 

--- a/lib/moment-range.js
+++ b/lib/moment-range.js
@@ -1,6 +1,7 @@
 import moment from 'moment';
 import Symbol from 'es6-symbol';
 
+
 //-----------------------------------------------------------------------------
 // Constants
 //-----------------------------------------------------------------------------
@@ -126,19 +127,25 @@ export class DateRange {
     return new this.constructor(this.start, this.end);
   }
 
-  contains(other, options = { exclusive: false }) {
+  contains(other, options = { excludeStart: false, excludeEnd: false }) {
     const start = this.start.valueOf();
     const end = this.end.valueOf();
     let oStart = other.valueOf();
     let oEnd = other.valueOf();
+    let excludeStart = options.excludeStart || false;
+    let excludeEnd = options.excludeEnd || false;
+
+    if (options.hasOwnProperty('exclusive')) {
+      excludeStart = excludeEnd = options.exclusive;
+    }
 
     if (other instanceof DateRange) {
       oStart = other.start.valueOf();
       oEnd = other.end.valueOf();
     }
 
-    const startInRange = (start < oStart) || ((start <= oStart) && !options.exclusive);
-    const endInRange = (end > oEnd) || ((end >= oEnd) && !options.exclusive);
+    const startInRange = (start < oStart) || ((start <= oStart) && !excludeStart);
+    const endInRange = (end > oEnd) || ((end >= oEnd) && !excludeEnd);
 
     return (startInRange && endInRange);
   }

--- a/lib/moment-range_test.js
+++ b/lib/moment-range_test.js
@@ -136,8 +136,8 @@ describe('DateRange', function() {
     it('should allow initialization with Jan 1 1970', function() {
       let dr = moment.range(0, 0);
 
-      expect(dr.start.year()).to.be(1970);
-      expect(dr.end.year()).to.be(1970);
+      expect(dr.start.utc().year()).to.be(1970);
+      expect(dr.end.utc().year()).to.be(1970);
 
       dr = moment.range(m1, false);
 
@@ -713,7 +713,7 @@ describe('DateRange', function() {
       expect(dr1.contains(dr1)).to.be(true);
     });
 
-    it('should be exlusive when the exclusive param is set', function() {
+    it('should be exlusive when the exclusive param is set (DEPRECATED)', function() {
       const dr1 = moment.range(m1, m2);
 
       expect(dr1.contains(dr1, { exclusive: true })).to.be(false);
@@ -722,6 +722,24 @@ describe('DateRange', function() {
       expect(dr1.contains(m2, { exclusive: true })).to.be(false);
       expect(dr1.contains(m2, { exclusive: false })).to.be(true);
       expect(dr1.contains(m2)).to.be(true);
+    });
+
+    it('should exclude the start date when `excludeStart` is set to `true`', function() {
+      const start = moment('2017-12-01');
+      const end = moment('2017-12-01');
+      const range = moment.range(start, end);
+
+      expect(range.contains(start)).to.be(true);
+      expect(range.contains(start, { excludeStart: true })).to.be(false);
+    });
+
+    it('should exclude the end date when `excludeEnd` is set to `true`', function() {
+      const start = moment('2017-12-01');
+      const end = moment('2017-12-01');
+      const range = moment.range(start, end);
+
+      expect(range.contains(end)).to.be(true);
+      expect(range.contains(end, { excludeEnd: true })).to.be(false);
     });
   });
 

--- a/typing-tests/moment-range_test.ts
+++ b/typing-tests/moment-range_test.ts
@@ -62,9 +62,18 @@ const range007 = new DateRange('year');
 range007.contains(new Date());
 range007.contains(new DateRange('day'));
 range007.contains(moment());
-range007.contains(new Date(), {exclusive: true});
-range007.contains(new DateRange('day'), {exclusive: true});
-range007.contains(moment(), {exclusive: true});
+range007.contains(new Date(), {excludeStart: true});
+range007.contains(new DateRange('day'), {excludeStart: true});
+range007.contains(moment(), {excludeStart: true});
+range007.contains(new Date(), {excludeEnd: true});
+range007.contains(new DateRange('day'), {excludeEnd: true});
+range007.contains(moment(), {excludeEnd: true});
+range007.contains(new Date(), {excludeStart: true, excludeEnd: true});
+range007.contains(new DateRange('day'), {excludeStart: true, excludeEnd: true});
+range007.contains(moment(), {excludeStart: true, excludeEnd: true});
+range007.contains(new Date(), {exclusive: true}); // DEPRECATED
+range007.contains(new DateRange('day'), {exclusive: true}); // DEPRECATED
+range007.contains(moment(), {exclusive: true}); // DEPRECATED
 
 // Diff
 const range008 = new DateRange('year');


### PR DESCRIPTION
* Deprecated `exclusive` option of `contains()` method in favour of new
  `excludeStart` and `excludeEnd` options
* Add tests
* Update both flow and typescript type definitions
* Closes #144 
* Closes #174 
  