### PR TITLE
Deprecated parseZoneRange, changed to rangeFromISOString

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * Deprecated `exclusive` option of `byRange()` method in favour of new `excludeEnd` options
 * Deprecated `exclusive` option of `reverseBy()` method in favour of new `excludeStart` options
 * Deprecated `exclusive` option of `reverseByRange()` method in favour of new `excludeStart` options
+* Deprecated `parseZoneRange` in favour of `rangeFromISOString`
 
 ### Added
 
@@ -26,6 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * Added `excludeStart` to `reverseBy()` method
 * Added `excludeStart` to `reverseByRange()` method
 * Added note about supporting older browsers with links to polyfills to the README
+* Added moment extension `rangeFromISOString`, changed name from `parseZoneRange`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * Changed `prepublishOnly` and `version` scripts to use `&&` instead of `;`
 * Changed `prepublish`, `preversion`, `version` scripts to support typescript definitions
 * Changed CircleCI config to also run typescript tests
+* Changed `parseZoneRange` to `rangeFromISOString` to follow naming conventions. Deprecated `parseZoneRange`.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ When using a negative interval, the date provided will be set as the end of the 
 
 #### parseZoneRange
 
-**DEPRECATED**: Replaced by `rangeFromISOString` to follow naming conventions.
+**DEPRECATED** in `4.0.0`: Replaced by `rangeFromISOString` to follow naming conventions.
 
 #### rangeFromISOString
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Fancy date ranges for [Moment.js][moment].
   - [Create](#create)
     - [rangeFromInterval](#rangefrominterval)
     - [parseZoneRange](#parsezonerange)
+    - [rangeFromISOString](#rangefromisostring)
   - [Attributes](#attributes)
   - [Querying](#querying)
     - [Adjacent](#adjacent)
@@ -180,12 +181,16 @@ When using a negative interval, the date provided will be set as the end of the 
 
 #### parseZoneRange
 
-Parses an [ISO 8601 time interval][interval] into a date range while
+**DEPRECATED**: Replaced by `rangeFromISOString` to follow naming conventions.
+
+#### rangeFromISOString
+
+Converts an [ISO 8601 time interval string][interval] into a date range while
 preserving the time zones using [moment.parseZone][parseZone].
 
 ``` js
 const interval = '2015-01-17T09:50:00+03:00/2015-04-17T08:29:55-04:00';
-const range = moment.parseZoneRange(interval);
+const range = moment.rangeFromISOString(interval);
 
 range.toString(); // '2015-01-17T09:50:00+03:00/2015-04-17T08:29:55-04:00'
 ```

--- a/declarations/moment.js.flow
+++ b/declarations/moment.js.flow
@@ -241,8 +241,11 @@ declare class moment$Moment {
   range(start: Date, end: Date): DateRange;
   range(start: Moment, end: Moment): DateRange;
   rangeFromInterval(interval: string, count?: number, date?: Date|Moment|string): DateRange;
-  parseZoneRange(isoTimeInterval: string): DateRange;
+  rangeFromISOString(isoTimeInterval: string): DateRange;
   within(range: DateRange): bool;
+
+  // @deprecated
+  parseZoneRange(isoTimeInterval: string): DateRange;
 }
 
 declare module 'moment' {

--- a/lib/moment-range.d.ts
+++ b/lib/moment-range.d.ts
@@ -70,7 +70,7 @@ export interface MomentRangeStaticMethods {
   rangeFromInterval(interval: unitOfTime.Diff, count?: number, date?: Date | Moment): DateRange;
   rangeFromISOString(isoTimeInterval: string): DateRange;
 
-  // @deprecated
+  // @deprecated 4.0.0
   parseZoneRange(isoTimeInterval: string): DateRange;
 }
 

--- a/lib/moment-range.d.ts
+++ b/lib/moment-range.d.ts
@@ -61,8 +61,6 @@ export class DateRange {
 }
 
 export interface MomentRangeStaticMethods {
-  parseZoneRange(isoTimeInterval: string): DateRange;
-
   range(start: Date, end: Date): DateRange;
   range(start: Moment, end: Moment): DateRange;
   range(range: [Date, Date]): DateRange;
@@ -70,6 +68,10 @@ export interface MomentRangeStaticMethods {
   range(range: string): DateRange;
 
   rangeFromInterval(interval: unitOfTime.Diff, count?: number, date?: Date | Moment): DateRange;
+  rangeFromISOString(isoTimeInterval: string): DateRange;
+
+  // @deprecated
+  parseZoneRange(isoTimeInterval: string): DateRange;
 }
 
 export interface MomentRange extends MomentRangeStaticMethods {

--- a/lib/moment-range.js
+++ b/lib/moment-range.js
@@ -389,12 +389,14 @@ export function extendMoment(moment) {
    * @param {string} isoTimeInterval the timeInterval to be parsed
    * @return {DateRange} constructed using moments that will preserve the time zones
    */
-  moment.parseZoneRange = function(isoTimeInterval) {
+  moment.rangeFromISOString = function(isoTimeInterval) {
     const momentStrings = isoSplit(isoTimeInterval);
     const start = moment.parseZone(momentStrings[0]);
     const end = moment.parseZone(momentStrings[1]);
     return new DateRange(start, end);
   };
+
+  moment.parseZoneRange = moment.rangeFromISOString; // DEPRECATED
 
   /**
    * Alias of static constructor.

--- a/lib/moment-range.js
+++ b/lib/moment-range.js
@@ -396,7 +396,7 @@ export function extendMoment(moment) {
     return new DateRange(start, end);
   };
 
-  moment.parseZoneRange = moment.rangeFromISOString; // DEPRECATED
+  moment.parseZoneRange = moment.rangeFromISOString; // DEPRECATED 4.0.0
 
   /**
    * Alias of static constructor.

--- a/lib/moment-range_test.js
+++ b/lib/moment-range_test.js
@@ -112,7 +112,7 @@ describe('DateRange', function() {
       const start = '2015-01-17T09:50:04+03:00';
       const end   = '2015-04-17T08:29:55-04:00';
       const timeInterval = start + '/' + end;
-      const range = moment.parseZoneRange(timeInterval);
+      const range = moment.rangeFromISOString(timeInterval);
       expect(range.toString()).equal(timeInterval);
     });
 

--- a/typing-tests/moment-range_test.ts
+++ b/typing-tests/moment-range_test.ts
@@ -19,7 +19,7 @@ moment.rangeFromInterval('day', 3);
 moment.rangeFromInterval('day', 3, moment());
 
 moment.rangeFromISOString('2015-01-17T09:50:04+03:00/2015-04-17T08:29:55-04:00');
-moment.parseZoneRange('2015-01-17T09:50:04+03:00/2015-04-17T08:29:55-04:00');   // DEPRECATED
+moment.parseZoneRange('2015-01-17T09:50:04+03:00/2015-04-17T08:29:55-04:00'); // DEPRECATED 4.0.0
 
 moment().isRange(moment.range('hour'));
 

--- a/typing-tests/moment-range_test.ts
+++ b/typing-tests/moment-range_test.ts
@@ -8,8 +8,6 @@ const moment = extendMoment(M);
 // Typescript Tests
 //-----------------------------------------------------------------------------
 
-moment.parseZoneRange('2015-01-17T09:50:04+03:00/2015-04-17T08:29:55-04:00');
-
 moment.range(new Date(), new Date());
 moment.range(moment(), moment());
 moment.range([new Date(), new Date()]);
@@ -19,6 +17,9 @@ moment.range('year');
 moment.rangeFromInterval('day');
 moment.rangeFromInterval('day', 3);
 moment.rangeFromInterval('day', 3, moment());
+
+moment.rangeFromISOString('2015-01-17T09:50:04+03:00/2015-04-17T08:29:55-04:00');
+moment.parseZoneRange('2015-01-17T09:50:04+03:00/2015-04-17T08:29:55-04:00');   // DEPRECATED
 
 moment().isRange(moment.range('hour'));
 


### PR DESCRIPTION
Deprecates `parseZoneRange`, replaced by `rangeFromISOString` to follow other naming conventions.

`parseZoneRange` will be removed in version 4.0.0.

Fixes https://github.com/rotaready/moment-range/issues/207