### PR TITLE
Deprecate `exclusive` option in methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 * Deprecated `exclusive` option of `contains()` method in favour of new
   `excludeStart` and `excludeEnd` options
+* Deprecated `exclusive` option of `by()` method in favour of new `excludeEnd` options
+* Deprecated `exclusive` option of `byRange()` method in favour of new `excludeEnd` options
+* Deprecated `exclusive` option of `reverseBy()` method in favour of new `excludeStart` options
+* Deprecated `exclusive` option of `reverseByRange()` method in favour of new `excludeStart` options
 
 ### Added
 
@@ -17,6 +21,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * Added Typescript config and tests
 * Added `check`, `typescript-test` npm script
 * Added `excludeStart` and `excludeEnd` to `contains()` method
+* Added `excludeEnd` to `by()` method
+* Added `excludeEnd` to `byRange()` method
+* Added `excludeStart` to `reverseBy()` method
+* Added `excludeStart` to `reverseByRange()` method
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ range.contains(c); // true
 range.contains(c, { excludeEnd: true; }); // false
 ```
 
-**DEPRECATED**: The `exclusive` options is used to indicate if the start/end of
+**DEPRECATED** in `4.0.0`: The `exclusive` options is used to indicate if the start/end of
 the range should be excluded when testing for inclusion:
 
 **Note**: You can obtain the same functionality by setting `{ excludeStart:
@@ -396,14 +396,14 @@ years.map(m => m.format('YYYY')) // ['2010', '2011', '2012', '2013', '2014', '20
 ```
 
 Iteration also supports excluding the end value of the range by setting the
-`exclusive` option to `true`.
+`excludeEnd` option to `true`.
 
 ``` js
 const start  = new Date(2012, 2, 1);
 const end    = new Date(2012, 2, 5);
 const range1 = moment.range(start, end);
 
-const acc = Array.from(range1.by('day', { exclusive: true }));
+const acc = Array.from(range1.by('day', { excludeEnd: true }));
 
 acc.length == 4 // true
 ```
@@ -419,10 +419,16 @@ let acc = Array.from(range1.by('day', { step: 2 }));
 
 acc.map(m => m.format('DD')) // ['02', '04', '06']
 
-acc = Array.from(range1.by('day', { exclusive: true, step: 2 }));
+acc = Array.from(range1.by('day', { excludeEnd: true, step: 2 }));
 
 acc.map(m => m.format('DD')) // ['02', '04']
 ```
+
+**DEPRECATED** in `4.0.0`: The `exclusive` options is used to indicate if the
+end of the range should be excluded when testing for inclusion:
+
+**Note**: You can obtain the same functionality by setting `{ excludeEnd: true }`
+
 
 #### byRange
 
@@ -445,7 +451,7 @@ acc.length == 5 // true
 Exclude the end value:
 
 ``` js
-const acc = Array.from(range1.by(range2, { exclusive: true }));
+const acc = Array.from(range1.by(range2, { excludeEnd: true }));
 
 acc.length == 4 // true
 ```
@@ -457,10 +463,16 @@ let acc = Array.from(range1.by(range2, { step: 2 }));
 
 acc.map(m => m.format('DD')) // ['01', '03', '05']
 
-acc = Array.from(range1.by(range2, { exlusive, true, step: 2 }));
+acc = Array.from(range1.by(range2, { excludeEnd, true, step: 2 }));
 
 acc.map(m => m.format('DD')) // ['01', '03']
 ```
+
+**DEPRECATED** in `4.0.0`: The `exclusive` options is used to indicate if the
+end of the range should be excluded when testing for inclusion:
+
+**Note**: You can obtain the same functionality by setting `{ excludeEnd: true }`
+
 
 #### reverseBy
 
@@ -472,11 +484,11 @@ const acc = Array.from(range.reverseBy('years'));
 acc.map(m => m.format('YYYY')) // ['2015', '2014', '2013', '2012']
 ```
 
-Exclude the end value:
+Exclude the start value:
 
 ``` js
 const range = moment.range('2012-01-01', '2015-01-01');
-const acc = Array.from(range.reverseBy('years', { exclusive: true }));
+const acc = Array.from(range.reverseBy('years', { excludeStart: true }));
 acc.map(m => m.format('YYYY')) // ['2015', '2014', '2013']
 ```
 
@@ -491,10 +503,16 @@ let acc = Array.from(range1.reverseBy('day', { step: 2 }));
 
 acc.map(m => m.format('DD')) // ['06', '04', '02']
 
-acc = Array.from(range1.reverseBy('day', { exclusive: true, step: 2 }));
+acc = Array.from(range1.reverseBy('day', { excludeStart: true, step: 2 }));
 
 acc.map(m => m.format('DD')) // ['06', '04']
 ```
+
+**DEPRECATED** in `4.0.0`: The `exclusive` options is used to indicate if the
+start of the range should be excluded when testing for inclusion:
+
+**Note**: You can obtain the same functionality by setting `{ excludeStart: true }`
+
 
 #### reverseByRange
 
@@ -515,10 +533,10 @@ acc.length == 5 // true
 acc.map(m => m.format('DD')) // ['05', '04', '03', '02', '01']
 ```
 
-Exclude the end value:
+Exclude the start value:
 
 ``` js
-const acc = Array.from(range1.by(range2, { exclusive: true }));
+const acc = Array.from(range1.by(range2, { excludeStart: true }));
 
 acc.length == 4 // true
 acc.map(m => m.format('DD')) // ['05', '04', '03', '02']
@@ -531,10 +549,16 @@ let acc = Array.from(range1.reverseByRange(range2, { step: 2 }));
 
 acc.map(m => m.format('DD')) // ['05', '03', '01']
 
-acc = Array.from(range1.reverseByRange(range2, { exlusive, true, step: 2 }));
+acc = Array.from(range1.reverseByRange(range2, { excludeStart: true, step: 2 }));
 
 acc.map(m => m.format('DD')) // ['05', '03']
 ```
+
+**DEPRECATED** in `4.0.0`: The `exclusive` options is used to indicate if the
+start of the range should be excluded when testing for inclusion:
+
+**Note**: You can obtain the same functionality by setting `{ excludeStart: true }`
+
 
 ### Compare
 

--- a/declarations/moment-range.js.flow
+++ b/declarations/moment-range.js.flow
@@ -19,17 +19,21 @@ declare module 'moment-range' {
 
     add(other: DateRange): ?DateRange;
 
+    by(interval: Shorthand, options?: { excludeEnd: bool; step: number; }): Iterable<Moment>;
+    // @deprecated 4.0.0
     by(interval: Shorthand, options?: { exclusive: bool; step: number; }): Iterable<Moment>;
 
+    byRange(interval: DateRange, options?: { excludeEnd: bool; step: number; }): Iterable<Moment>;
+    // @deprecated 4.0.0
     byRange(interval: DateRange, options?: { exclusive: bool; step: number; }): Iterable<Moment>;
 
     center(): Moment;
 
     clone(): DateRange;
 
-    // @deprecated
-    contains(other: Date | DateRange | Moment, options?: { exclusive: bool; }): bool;
     contains(other: Date | DateRange | Moment, options?: { excludeStart: bool; excludeEnd: bool; }): bool;
+    // @deprecated 4.0.0
+    contains(other: Date | DateRange | Moment, options?: { exclusive: bool; }): bool;
 
     diff(unit: ?Shorthand, rounded: ?bool): number;
 
@@ -43,8 +47,12 @@ declare module 'moment-range' {
 
     overlaps(other: DateRange, options: { adjacent: bool; }): bool;
 
+    reverseBy(interval: Shorthand, options?: { excludeStart: bool; step: number; }): Iterable<Moment>;
+    // @deprecated 4.0.0
     reverseBy(interval: Shorthand, options?: { exclusive: bool; step: number; }): Iterable<Moment>;
 
+    reverseByRange(interval: DateRange, options?: { excludeStart: bool; step: number; }): Iterable<Moment>;
+    // @deprecated 4.0.0
     reverseByRange(interval: DateRange, options?: { exclusive: bool; step: number; }): Iterable<Moment>;
 
     subtract(other: DateRange): Array<DateRange>;

--- a/lib/moment-range.d.ts
+++ b/lib/moment-range.d.ts
@@ -15,17 +15,21 @@ export class DateRange {
 
   add(other: DateRange): DateRange | undefined;
 
+  by(interval: unitOfTime.Diff, options?: { excludeEnd?: boolean; step?: number; }): Iterable<Moment>;
+  // @deprecated 4.0.0
   by(interval: unitOfTime.Diff, options?: { exclusive?: boolean; step?: number; }): Iterable<Moment>;
 
+  byRange(interval: DateRange, options?: { excludeEnd?: boolean; step?: number; }): Iterable<Moment>;
+  // @deprecated 4.0.0
   byRange(interval: DateRange, options?: { exclusive?: boolean; step?: number; }): Iterable<Moment>;
 
   center(): Moment;
 
   clone(): DateRange;
 
-  // @deprecated
-  contains(other: Date | DateRange | Moment, options?: { exclusive?: boolean; }): boolean;
   contains(other: Date | DateRange | Moment, options?: { excludeStart?: boolean; excludeEnd?: boolean; }): boolean;
+  // @deprecated 4.0.0
+  contains(other: Date | DateRange | Moment, options?: { exclusive?: boolean; }): boolean;
 
   diff(unit?: unitOfTime.Diff, rounded?: boolean): number;
 
@@ -39,8 +43,12 @@ export class DateRange {
 
   overlaps(other: DateRange, options?: { adjacent?: boolean; }): boolean;
 
+  reverseBy(interval: unitOfTime.Diff, options?: { excludeStart?: boolean; step?: number; }): Iterable<Moment>;
+  // @deprecated 4.0.0
   reverseBy(interval: unitOfTime.Diff, options?: { exclusive?: boolean; step?: number; }): Iterable<Moment>;
 
+  reverseByRange(interval: DateRange, options?: { excludeStart?: boolean; step?: number; }): Iterable<Moment>;
+  // @deprecated 4.0.0
   reverseByRange(interval: DateRange, options?: { exclusive?: boolean; step?: number; }): Iterable<Moment>;
 
   subtract(other: DateRange): DateRange[];

--- a/lib/moment-range.js
+++ b/lib/moment-range.js
@@ -55,20 +55,24 @@ export class DateRange {
     return null;
   }
 
-  by(interval, options = { exclusive: false, step: 1 }) {
+  by(interval, options = { excludeEnd: false, step: 1 }) {
     const range = this;
 
     return {
       [Symbol.iterator]() {
-        const exclusive = options.exclusive || false;
         const step = options.step || 1;
         const diff = Math.abs(range.start.diff(range.end, interval)) / step;
+        let excludeEnd = options.excludeEnd || false;
         let iteration = 0;
+
+        if (options.hasOwnProperty('exclusive')) {
+          excludeEnd = options.exclusive;
+        }
 
         return {
           next() {
             const current = range.start.clone().add((iteration * step), interval);
-            const done = exclusive
+            const done = excludeEnd
               ? !(iteration < diff)
               : !(iteration <= diff);
 
@@ -84,13 +88,17 @@ export class DateRange {
     };
   }
 
-  byRange(interval, options = { exclusive: false, step: 1 }) {
+  byRange(interval, options = { excludeEnd: false, step: 1 }) {
     const range = this;
     const step = options.step || 1;
     const diff = this.valueOf() / interval.valueOf() / step;
-    const exclusive = options.exclusive || false;
     const unit = Math.floor(diff);
+    let excludeEnd = options.excludeEnd || false;
     let iteration = 0;
+
+    if (options.hasOwnProperty('exclusive')) {
+      excludeEnd = options.exclusive;
+    }
 
     return {
       [Symbol.iterator]() {
@@ -101,7 +109,7 @@ export class DateRange {
         return {
           next() {
             const current = moment(range.start.valueOf() + (interval.valueOf() * iteration * step));
-            const done = ((unit === diff) && exclusive)
+            const done = ((unit === diff) && excludeEnd)
               ? !(iteration < unit)
               : !(iteration <= unit);
 
@@ -223,20 +231,24 @@ export class DateRange {
     return intersect;
   }
 
-  reverseBy(interval, options = { exclusive: false, step: 1 }) {
+  reverseBy(interval, options = { excludeStart: false, step: 1 }) {
     const range = this;
 
     return {
       [Symbol.iterator]() {
-        const exclusive = options.exclusive || false;
         const step = options.step || 1;
         const diff = Math.abs(range.start.diff(range.end, interval)) / step;
+        let excludeStart = options.excludeStart || false;
         let iteration = 0;
+
+        if (options.hasOwnProperty('exclusive')) {
+          excludeStart = options.exclusive;
+        }
 
         return {
           next() {
             const current = range.end.clone().subtract((iteration * step), interval);
-            const done = exclusive
+            const done = excludeStart
               ? !(iteration < diff)
               : !(iteration <= diff);
 
@@ -252,13 +264,17 @@ export class DateRange {
     };
   }
 
-  reverseByRange(interval, options = { exclusive: false, step: 1 }) {
+  reverseByRange(interval, options = { excludeStart: false, step: 1 }) {
     const range = this;
     const step = options.step || 1;
     const diff = this.valueOf() / interval.valueOf() / step;
-    const exclusive = options.exclusive || false;
     const unit = Math.floor(diff);
+    let excludeStart = options.excludeStart || false;
     let iteration = 0;
+
+    if (options.hasOwnProperty('exclusive')) {
+      excludeStart = options.exclusive;
+    }
 
     return {
       [Symbol.iterator]() {
@@ -269,7 +285,7 @@ export class DateRange {
         return {
           next() {
             const current = moment(range.end.valueOf() - (interval.valueOf() * iteration * step));
-            const done = ((unit === diff) && exclusive)
+            const done = ((unit === diff) && excludeStart)
               ? !(iteration < unit)
               : !(iteration <= unit);
 

--- a/lib/moment-range_test.js
+++ b/lib/moment-range_test.js
@@ -316,11 +316,11 @@ describe('DateRange', function() {
       expect(acc).to.eql(['2012-01', '2012-02', '2012-03']);
     });
 
-    it('should not include .end in the iteration if exclusive is set to true when iterating by string', function() {
+    it('should not include .end in the iteration if `excludeEnd` is set to `true` when iterating by string', function() {
       const my1 = moment('2014-04-02T00:00:00.000Z');
       const my2 = moment('2014-04-04T00:00:00.000Z');
       const dr1 = moment.range(my1, my2);
-      const options = { exclusive: true };
+      const options = { excludeEnd: true };
       let acc;
 
       acc = Array.from(dr1.by('d', options)).map(m => m.utc().format('YYYY-MM-DD'));
@@ -330,11 +330,11 @@ describe('DateRange', function() {
       expect(acc).to.eql(['2014-04-02', '2014-04-03', '2014-04-04']);
     });
 
-    it('should be exlusive when using by with minutes as well', function() {
+    it('should `excludeEnd` when using by with minutes as well', function() {
       const d1 = moment('2014-01-01T00:00:00.000Z');
       const d2 = moment('2014-01-01T00:06:00.000Z');
       const dr = moment.range(d1, d2);
-      const options = { exclusive: true };
+      const options = { excludeEnd: true };
       let acc;
 
       acc = Array.from(dr.by('m')).map(m => m.utc().format('mm'));
@@ -353,13 +353,23 @@ describe('DateRange', function() {
       expect(acc).to.eql(['02', '04', '06', '08']);
     });
 
-    it('should correctly iterate by a given step when exclusive', function() {
+    it('should correctly iterate by a given step when `excludeEnd` is true', function() {
       const my1 = moment('2014-04-02T00:00:00.000Z');
       const my2 = moment('2014-04-08T00:00:00.000Z');
       const dr1 = moment.range(my1, my2);
 
-      const acc = Array.from(dr1.by('days', { exclusive: true, step: 2 })).map(m => m.utc().format('DD'));
+      const acc = Array.from(dr1.by('days', { excludeEnd: true, step: 2 })).map(m => m.utc().format('DD'));
       expect(acc).to.eql(['02', '04', '06']);
+    });
+
+    it('should alias `exclusive` to `excludeEnd`', function() {
+      const d1 = moment('2014-01-01T00:00:00.000Z');
+      const d2 = moment('2014-01-01T00:06:00.000Z');
+      const dr = moment.range(d1, d2);
+      const acc1 = Array.from(dr.by('m', { excludeEnd: true })).map(m => m.utc().format('mm'));
+      const acc2 = Array.from(dr.by('m', { exclusive: true })).map(m => m.utc().format('mm'));
+
+      expect(acc2).to.eql(acc1);
     });
   });
 
@@ -443,11 +453,11 @@ describe('DateRange', function() {
       expect(acc).to.eql(['2012-03', '2012-02', '2012-01']);
     });
 
-    it('should not include .start in the iteration if exclusive is set to true when iterating by string', function() {
+    it('should not include .start in the iteration if `excludeStart` is set to `true` when iterating by string', function() {
       const my1 = moment.utc('2014-04-02T00:00:00');
       const my2 = moment.utc('2014-04-04T23:59:59');
       const dr1 = moment.range(my1, my2);
-      const options = { exclusive: true };
+      const options = { excludeStart: true };
       let acc;
 
       acc = Array.from(dr1.reverseBy('d', options)).map(m => m.utc().format('YYYY-MM-DD'));
@@ -457,11 +467,11 @@ describe('DateRange', function() {
       expect(acc).to.eql(['2014-04-04', '2014-04-03', '2014-04-02']);
     });
 
-    it('should be exlusive when using by with minutes as well', function() {
+    it('should `excludeStart` when using by with minutes as well', function() {
       const d1 = moment('2014-01-01T00:00:00.000Z');
       const d2 = moment('2014-01-01T00:06:00.000Z');
       const dr = moment.range(d1, d2);
-      const options = { exclusive: true };
+      const options = { excludeStart: true };
       let acc;
 
       acc = Array.from(dr.reverseBy('m')).map(m => m.utc().format('mm'));
@@ -480,13 +490,22 @@ describe('DateRange', function() {
       expect(acc).to.eql(['08', '06', '04', '02']);
     });
 
-    it('should correctly iterate by a given step when exclusive', function() {
+    it('should correctly iterate by a given step when `excludeStart` is `true`', function() {
       const my1 = moment('2014-04-02T00:00:00.000Z');
       const my2 = moment('2014-04-08T00:00:00.000Z');
       const dr1 = moment.range(my1, my2);
 
-      const acc = Array.from(dr1.reverseBy('days', { exclusive: true, step: 2 })).map(m => m.utc().format('DD'));
+      const acc = Array.from(dr1.reverseBy('days', { excludeStart: true, step: 2 })).map(m => m.utc().format('DD'));
       expect(acc).to.eql(['08', '06', '04']);
+    });
+
+    it('should alias `exclusive` to `excludeStart`', function() {
+      const d1 = moment('2014-01-01T00:00:00.000Z');
+      const d2 = moment('2014-01-01T00:06:00.000Z');
+      const dr = moment.range(d1, d2);
+      const acc1 = Array.from(dr.reverseBy('m', { excludeStart: true })).map(m => m.utc().format('mm'));
+      const acc2 = Array.from(dr.reverseBy('m', { exclusive: true })).map(m => m.utc().format('mm'));
+      expect(acc2).to.eql(acc1);
     });
   });
 
@@ -546,7 +565,7 @@ describe('DateRange', function() {
       expect(acc[95].minute()).to.eql(45);
     });
 
-    it('should not include .end in the iteration if exclusive is set to true when iterating by range', function() {
+    it('should not include .end in the iteration if `excludeEnd` is set to `true` when iterating by range', function() {
       const my1 = moment('2014-04-02T00:00:00.000Z');
       const my2 = moment('2014-04-04T00:00:00.000Z');
       const dr1 = moment.range(my1, my2);
@@ -556,10 +575,10 @@ describe('DateRange', function() {
       acc = Array.from(dr1.byRange(dr2)).map(m => m.utc().format('YYYY-MM-DD'));
       expect(acc).to.eql(['2014-04-02', '2014-04-03', '2014-04-04']);
 
-      acc = Array.from(dr1.byRange(dr2, { exclusive: false })).map(m => m.utc().format('YYYY-MM-DD'));
+      acc = Array.from(dr1.byRange(dr2, { excludeEnd: false })).map(m => m.utc().format('YYYY-MM-DD'));
       expect(acc).to.eql(['2014-04-02', '2014-04-03', '2014-04-04']);
 
-      acc = Array.from(dr1.byRange(dr2, { exclusive: true })).map(m => m.utc().format('YYYY-MM-DD'));
+      acc = Array.from(dr1.byRange(dr2, { excludeEnd: true })).map(m => m.utc().format('YYYY-MM-DD'));
       expect(acc).to.eql(['2014-04-02', '2014-04-03']);
     });
 
@@ -574,15 +593,25 @@ describe('DateRange', function() {
       expect(acc).to.eql(['02', '04', '06']);
     });
 
-    it('should iterate correctly by a given step when exclusive', function() {
+    it('should iterate correctly by a given step when `excludeEnd` is `true`', function() {
       const d1 = new Date(Date.UTC(2012, 2, 2));
       const d2 = new Date(Date.UTC(2012, 2, 6));
       const dr1 = moment.range(d1, d2);
       const dr2 = 1000 * 60 * 60 * 24;
 
-      const acc = Array.from(dr1.byRange(dr2, { exclusive: true, step: 2 })).map(m => m.utc().format('DD'));
+      const acc = Array.from(dr1.byRange(dr2, { excludeEnd: true, step: 2 })).map(m => m.utc().format('DD'));
 
       expect(acc).to.eql(['02', '04']);
+    });
+
+    it('should alias `exclusive` to `excludeEnd`', function() {
+      const my1 = moment('2014-04-02T00:00:00.000Z');
+      const my2 = moment('2014-04-04T00:00:00.000Z');
+      const dr1 = moment.range(my1, my2);
+      const dr2 = moment.range(my1, moment('2014-04-03T00:00:00.000Z'));
+      const acc1 = Array.from(dr1.byRange(dr2, { excludeEnd: true })).map(m => m.utc().format('YYYY-MM-DD'));
+      const acc2 = Array.from(dr1.byRange(dr2, { exclusive: true })).map(m => m.utc().format('YYYY-MM-DD'));
+      expect(acc2).to.eql(acc1);
     });
   });
 
@@ -642,7 +671,7 @@ describe('DateRange', function() {
       expect(acc[95].minute()).to.eql(15);
     });
 
-    it('should not include .start in the iteration if exclusive is set to true when iterating by range', function() {
+    it('should not include .start in the iteration if `excludeStart` is set to `true` when iterating by range', function() {
       const my1 = moment('2014-04-02T00:00:00.000Z');
       const my2 = moment('2014-04-04T00:00:00.000Z');
       const dr1 = moment.range(my1, my2);
@@ -652,10 +681,10 @@ describe('DateRange', function() {
       acc = Array.from(dr1.reverseByRange(dr2)).map(m => m.utc().format('YYYY-MM-DD'));
       expect(acc).to.eql(['2014-04-04', '2014-04-03', '2014-04-02']);
 
-      acc = Array.from(dr1.reverseByRange(dr2, { exclusive: false })).map(m => m.utc().format('YYYY-MM-DD'));
+      acc = Array.from(dr1.reverseByRange(dr2, { excludeStart: false })).map(m => m.utc().format('YYYY-MM-DD'));
       expect(acc).to.eql(['2014-04-04', '2014-04-03', '2014-04-02']);
 
-      acc = Array.from(dr1.reverseByRange(dr2, { exclusive: true })).map(m => m.utc().format('YYYY-MM-DD'));
+      acc = Array.from(dr1.reverseByRange(dr2, { excludeStart: true })).map(m => m.utc().format('YYYY-MM-DD'));
       expect(acc).to.eql(['2014-04-04', '2014-04-03']);
     });
 
@@ -670,15 +699,25 @@ describe('DateRange', function() {
       expect(acc).to.eql(['06', '04', '02']);
     });
 
-    it('should iterate correctly by a given step when exclusive', function() {
+    it('should iterate correctly by a given step when `excludeStart` is `true`', function() {
       const d1 = new Date(Date.UTC(2012, 2, 2));
       const d2 = new Date(Date.UTC(2012, 2, 6));
       const dr1 = moment.range(d1, d2);
       const dr2 = 1000 * 60 * 60 * 24;
 
-      const acc = Array.from(dr1.reverseByRange(dr2, { exclusive: true, step: 2 })).map(m => m.utc().format('DD'));
+      const acc = Array.from(dr1.reverseByRange(dr2, { excludeStart: true, step: 2 })).map(m => m.utc().format('DD'));
 
       expect(acc).to.eql(['06', '04']);
+    });
+
+    it('should alias `exclusive` to `excludeEnd`', function() {
+      const my1 = moment('2014-04-02T00:00:00.000Z');
+      const my2 = moment('2014-04-04T00:00:00.000Z');
+      const dr1 = moment.range(my1, my2);
+      const dr2 = moment.range(my1, moment('2014-04-03T00:00:00.000Z'));
+      const acc1 = Array.from(dr1.reverseByRange(dr2, { excludeStart: true })).map(m => m.utc().format('YYYY-MM-DD'));
+      const acc2 = Array.from(dr1.reverseByRange(dr2, { exclusive: true })).map(m => m.utc().format('YYYY-MM-DD'));
+      expect(acc2).to.eql(acc1);
     });
   });
 
@@ -713,7 +752,7 @@ describe('DateRange', function() {
       expect(dr1.contains(dr1)).to.be(true);
     });
 
-    it('should be exlusive when the exclusive param is set (DEPRECATED)', function() {
+    it('should exclude the start and end values when the exclusive param is set (DEPRECATED)', function() {
       const dr1 = moment.range(m1, m2);
 
       expect(dr1.contains(dr1, { exclusive: true })).to.be(false);

--- a/typing-tests/moment-range_test.ts
+++ b/typing-tests/moment-range_test.ts
@@ -41,13 +41,17 @@ range002.add(new DateRange('month'));
 // By
 const range003 = new DateRange('year');
 range003.by('months');
-range003.by('months', {exclusive: true});
+range003.by('months', {excludeEnd: true});
+range003.by('months', {exclusive: true}); // DEPRECATED 4.0.0
 range003.by('months', {step: 2});
-range003.by('months', {exclusive: true, step: 2});
+range003.by('months', {excludeEnd: true, step: 2});
+range003.by('months', {exclusive: true, step: 2}); // DEPRECATED 4.0.0
 
 // By Range
 const range004 = new DateRange('year');
 range004.byRange(new DateRange('month'));
+range004.byRange(new DateRange('month'), {excludeEnd: true});
+range004.byRange(new DateRange('month'), {exclusive: true}); // DEPRECATED 4.0.0
 
 // Center
 const range005 = new DateRange('year');
@@ -71,9 +75,9 @@ range007.contains(moment(), {excludeEnd: true});
 range007.contains(new Date(), {excludeStart: true, excludeEnd: true});
 range007.contains(new DateRange('day'), {excludeStart: true, excludeEnd: true});
 range007.contains(moment(), {excludeStart: true, excludeEnd: true});
-range007.contains(new Date(), {exclusive: true}); // DEPRECATED
-range007.contains(new DateRange('day'), {exclusive: true}); // DEPRECATED
-range007.contains(moment(), {exclusive: true}); // DEPRECATED
+range007.contains(new Date(), {exclusive: true}); // DEPRECATED 4.0.0
+range007.contains(new DateRange('day'), {exclusive: true}); // DEPRECATED 4.0.0
+range007.contains(moment(), {exclusive: true}); // DEPRECATED 4.0.0
 
 // Diff
 const range008 = new DateRange('year');
@@ -107,13 +111,17 @@ range013.overlaps(new DateRange('month'), {adjacent: true});
 // Reverse By
 const range014 = new DateRange('year');
 range014.reverseBy('months');
-range014.reverseBy('months', {exclusive: true});
+range014.reverseBy('months', {excludeStart: true});
+range014.reverseBy('months', {exclusive: true}); // DEPRECATED 4.0.0
 range014.reverseBy('months', {step: 2});
-range014.reverseBy('months', {exclusive: true, step: 2});
+range014.reverseBy('months', {excludeStart: true, step: 2});
+range014.reverseBy('months', {exclusive: true, step: 2}); // DEPRECATED 4.0.0
 
 // Reverse By Range
 const range015 = new DateRange('year');
 range015.reverseByRange(new DateRange('month'));
+range015.reverseByRange(new DateRange('month'), {excludeStart: true});
+range015.reverseByRange(new DateRange('month'), {exclusive: true}); // DEPRECATED 4.0.0
 
 // Subtract
 const range016 = new DateRange('year');


### PR DESCRIPTION
* Added `excludeEnd` to `by()` method, deprecate `exclusive`
* Added `excludeEnd` to `byRange()` method, deprecate `exclusive`
* Added `excludeStart` to `reverseBy()` method, deprecate `exclusive`
* Added `excludeStart` to `reverseByRange()` method, deprecate `exclusive`
* Update type files
* Add tests
* Add docs
* Related to #208
* Closes #154 
* Closes #174 
* Closes #144