### PR TITLE
Added snapTo() method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-* Added Typescript defitions
+* Added Typescript definitions
 * Added Typescript config and tests
 * Added `check`, `typescript-test` npm script
 * Added `excludeStart` and `excludeEnd` to `contains()` method
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * Added `excludeStart` to `reverseByRange()` method
 * Added note about supporting older browsers with links to polyfills to the README
 * Added moment extension `rangeFromISOString`, changed name from `parseZoneRange`
+* Added `snapTo()` method
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -464,7 +464,7 @@ You can iterate over the span of a range for a period that is entered but not co
 const start = moment("2017-01-01T13:30:00");
 const end = moment("2017-01-05T01:45:12");
 const r1 = moment.range(start, end);
-const r2 = range1.snapTo('day');
+const r2 = r1.snapTo('day');
 
 Array.from(r1.by('days')).map(m => m.format('DD')); // ['01', '02', '03', '04']
 Array.from(r2.by('days')).map(m => m.format('DD')); // ['01', '02', '03', '04', '05']

--- a/README.md
+++ b/README.md
@@ -373,6 +373,21 @@ range2.start.add(2, 'days');
 range1.start.toDate().getTime() === range2.start.toDate().getTime() // false
 ```
 
+#### snapTo
+
+Snap the start and end of a range to a given interval.
+
+``` js
+const start = moment('2018-01-25 17:05:33');
+const end = moment('2018-01-28 06:10:00');
+
+const range1 = moment.range(start, end);
+const range2 = range1.snapTo('day'); // 2018-01-25T00:00:00 -> 2018-01-28T23:59:59
+
+range1.diff('days'); // 2
+range2.diff('days'); // 3
+```
+
 #### Subtract
 
 Subtracting one range from another.
@@ -440,6 +455,18 @@ acc.map(m => m.format('DD')) // ['02', '04', '06']
 acc = Array.from(range1.by('day', { excludeEnd: true, step: 2 }));
 
 acc.map(m => m.format('DD')) // ['02', '04']
+```
+
+You can iterate over the span of a range for a period that is entered but not complete by using the [snapTo][snapTo] method:
+
+``` js
+const start = moment("2017-01-01T13:30:00");
+const end = moment("2017-01-05T01:45:12");
+const r1 = moment.range(start, end);
+const r2 = range1.snapTo('day');
+
+Array.from(r1.by('days')).map(m => m.format('MM-DD')); // [ '01-01', '01-02', '01-03', '01-04' ]
+Array.from(r2.by('days')).map(m => m.format('MM-DD')); // [ '01-01', '01-02', '01-03', '01-04', '01-05' ]
 ```
 
 **DEPRECATED** in `4.0.0`: The `exclusive` options is used to indicate if the

--- a/README.md
+++ b/README.md
@@ -466,8 +466,8 @@ const end = moment("2017-01-05T01:45:12");
 const r1 = moment.range(start, end);
 const r2 = range1.snapTo('day');
 
-Array.from(r1.by('days')).map(m => m.format('MM-DD')); // [ '01-01', '01-02', '01-03', '01-04' ]
-Array.from(r2.by('days')).map(m => m.format('MM-DD')); // [ '01-01', '01-02', '01-03', '01-04', '01-05' ]
+Array.from(r1.by('days')).map(m => m.format('DD')); // ['01', '02', '03', '04']
+Array.from(r2.by('days')).map(m => m.format('DD')); // ['01', '02', '03', '04', '05']
 ```
 
 **DEPRECATED** in `4.0.0`: The `exclusive` options is used to indicate if the

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Fancy date ranges for [Moment.js][moment].
   - [Manipulation](#manipulation)
     - [Add](#add)
     - [Clone](#clone)
-    - [snapTo](#snapto)
+    - [SnapTo](#snapto)
     - [Subtract](#subtract)
   - [Iteration](#iteration)
     - [by](#by)
@@ -374,7 +374,7 @@ range2.start.add(2, 'days');
 range1.start.toDate().getTime() === range2.start.toDate().getTime() // false
 ```
 
-#### snapTo
+#### SnapTo
 
 Snap the start and end of a range to a given interval.
 
@@ -458,7 +458,7 @@ acc = Array.from(range1.by('day', { excludeEnd: true, step: 2 }));
 acc.map(m => m.format('DD')) // ['02', '04']
 ```
 
-You can iterate over the span of a range for a period that is entered but not complete by using the [snapTo][snapTo] method:
+You can iterate over the span of a range for a period that is entered but not complete by using the [snapTo()](#snapto) method:
 
 ``` js
 const start = moment("2017-01-01T13:30:00");

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Fancy date ranges for [Moment.js][moment].
   - [Manipulation](#manipulation)
     - [Add](#add)
     - [Clone](#clone)
+    - [snapTo](#snapto)
     - [Subtract](#subtract)
   - [Iteration](#iteration)
     - [by](#by)

--- a/declarations/moment-range.js.flow
+++ b/declarations/moment-range.js.flow
@@ -55,6 +55,8 @@ declare module 'moment-range' {
     // @deprecated 4.0.0
     reverseByRange(interval: DateRange, options?: { exclusive: bool; step: number; }): Iterable<Moment>;
 
+    snapTo(interval: Shorthand): DateRange;
+
     subtract(other: DateRange): Array<DateRange>;
 
     toDate(): Array<Date>;

--- a/lib/moment-range.d.ts
+++ b/lib/moment-range.d.ts
@@ -51,6 +51,8 @@ export class DateRange {
   // @deprecated 4.0.0
   reverseByRange(interval: DateRange, options?: { exclusive?: boolean; step?: number; }): Iterable<Moment>;
 
+  snapTo(interval: unitOfTime.Diff): DateRange;
+
   subtract(other: DateRange): DateRange[];
 
   toDate(): [Date, Date];

--- a/lib/moment-range.js
+++ b/lib/moment-range.js
@@ -132,7 +132,7 @@ export class DateRange {
   }
 
   clone() {
-    return new this.constructor(this.start, this.end);
+    return new this.constructor(this.start.clone(), this.end.clone());
   }
 
   contains(other, options = { excludeStart: false, excludeEnd: false }) {

--- a/lib/moment-range.js
+++ b/lib/moment-range.js
@@ -301,6 +301,21 @@ export class DateRange {
     };
   }
 
+  snapTo(interval) {
+    let snappedStart = this.start;
+    let snappedEnd = this.end;
+
+    // Snap if not open-ended range
+    if (!this.start.isSame(moment(-8640000000000000))) {
+      snappedStart = this.start.startOf(interval);
+    }
+    if (!this.end.isSame(moment(8640000000000000))) {
+      snappedEnd = this.end.endOf(interval);
+    }
+
+    return new this.constructor(snappedStart, snappedEnd);
+  }
+
   subtract(other) {
     const start = this.start.valueOf();
     const end = this.end.valueOf();

--- a/lib/moment-range.js
+++ b/lib/moment-range.js
@@ -302,18 +302,17 @@ export class DateRange {
   }
 
   snapTo(interval) {
-    let snappedStart = this.start;
-    let snappedEnd = this.end;
+    const r = this.clone();
 
     // Snap if not open-ended range
-    if (!this.start.isSame(moment(-8640000000000000))) {
-      snappedStart = this.start.startOf(interval);
+    if (!r.start.isSame(moment(-8640000000000000))) {
+      r.start = r.start.startOf(interval);
     }
-    if (!this.end.isSame(moment(8640000000000000))) {
-      snappedEnd = this.end.endOf(interval);
+    if (!r.end.isSame(moment(8640000000000000))) {
+      r.end = r.end.endOf(interval);
     }
 
-    return new this.constructor(snappedStart, snappedEnd);
+    return r;
   }
 
   subtract(other) {

--- a/lib/moment-range_test.js
+++ b/lib/moment-range_test.js
@@ -1121,6 +1121,13 @@ describe('DateRange', function() {
       expect(moment.isMoment(dr2.start)).to.be(true);
       expect(moment.isMoment(dr2.end)).to.be(true);
     });
+
+    it('should create a new date range', function() {
+      const dr3 = moment.range(d1, d2);
+      const dr4 = dr3.snapTo('day');
+
+      expect(dr3.isSame(dr4)).to.be(false);
+    });
   });
 
   describe('#subtract()', function() {

--- a/lib/moment-range_test.js
+++ b/lib/moment-range_test.js
@@ -1123,6 +1123,8 @@ describe('DateRange', function() {
     });
 
     it('should create a new date range', function() {
+      const d1 = moment('2018-02-01T03:00:00');
+      const d2 = moment('2018-03-01T13:00:00');
       const dr3 = moment.range(d1, d2);
       const dr4 = dr3.snapTo('day');
 

--- a/lib/moment-range_test.js
+++ b/lib/moment-range_test.js
@@ -1103,6 +1103,26 @@ describe('DateRange', function() {
     });
   });
 
+  describe('#snapTo()', function() {
+    const d1 = moment('2018-02-01T03:00:00');
+    const d2 = moment('2018-03-01T13:00:00');
+
+    it('should snap start and end of range to given interval', function() {
+      const dr1 = moment.range(d1, d2).snapTo('day');
+
+      expect(dr1.start.isSame(d1.startOf('day'))).to.be(true);
+      expect(dr1.end.isSame(d2.endOf('day'))).to.be(true);
+    });
+
+    it('should provide valid dates if open-ended range', function() {
+      const dr2 = moment.range(false, false).snapTo('week');
+
+      expect(dr2).to.eql(moment.range(false, false));
+      expect(moment.isMoment(dr2.start)).to.be(true);
+      expect(moment.isMoment(dr2.end)).to.be(true);
+    });
+  });
+
   describe('#subtract()', function() {
     const d5 = new Date(Date.UTC(2011, 2, 2));
     const d6 = new Date(Date.UTC(2011, 4, 4));

--- a/typing-tests/moment-range_test.ts
+++ b/typing-tests/moment-range_test.ts
@@ -124,20 +124,24 @@ range015.reverseByRange(new DateRange('month'));
 range015.reverseByRange(new DateRange('month'), {excludeStart: true});
 range015.reverseByRange(new DateRange('month'), {exclusive: true}); // DEPRECATED 4.0.0
 
-// Subtract
+// SnapTo
 const range016 = new DateRange('year');
-range016.subtract(new DateRange('month'));
+range016.snapTo('month');
+
+// Subtract
+const range017 = new DateRange('year');
+range017.subtract(new DateRange('month'));
 
 // To Date
-const range017 = new DateRange('year');
-range017.toDate();
+const range018 = new DateRange('year');
+range018.toDate();
 
 // To String
-const range018 = new DateRange('year');
-range018.toString();
-range018 + '';
+const range019 = new DateRange('year');
+range019.toString();
+range019 + '';
 
 // Value Of
-const range019 = new DateRange('year');
-range019.valueOf();
+const range020 = new DateRange('year');
+range020.valueOf();
 // range019 + 1;


### PR DESCRIPTION
Fixes https://github.com/rotaready/moment-range/issues/198

Snaps start and end of a range to a desired interval.
Allows you to iterate over the span of a range for a period that is entered but not complete
eg.
``` js
const start = moment("2017-01-01T13:30:00");
const end = moment("2017-01-05T01:45:12");
const r1 = moment.range(start, end); // by('days') -> ['01', '02', '03', '04']
const r2 = range1.snapTo('day'); // by('days') -> ['01', '02', '03', '04', '05']
```