### PR TITLE
Remove the test file from the package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
 declarations/
 flow-typed/
+lib/moment-range_test.js
 package-lock.json


### PR DESCRIPTION
The tests use `expect.js` which is a dev dependency, so `flow` complains about a missing module. And you wouldn't be able to run the tests anyway, so it seems pointless to have the file in the package.