### PR TITLE
Fixed range constructor poor performance when passed moment obj

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 * Fixed `intersect` not creating a new DateRange instance in all cases
 * Fixed Flow declaration to provide correct and stricter typings
+* Fixed DateRange constructor poor performance when passed moment objects
 
 ### Removed
 

--- a/lib/moment-range.js
+++ b/lib/moment-range.js
@@ -369,7 +369,7 @@ export function extendMoment(moment) {
   moment.range = function range(start, end) {
     const m = this;
 
-    if (INTERVALS.hasOwnProperty(start)) {
+    if (typeof start === 'string' && INTERVALS.hasOwnProperty(start)) {
       return new DateRange(moment(m).startOf(start), moment(m).endOf(start));
     }
 


### PR DESCRIPTION
Fixes: https://github.com/rotaready/moment-range/issues/236

Constructor now checks for type string to prevent overhead when attempting to convert moment object to a string.

This part of constructor is used to create a range from a moment object on a given interval:
```js
const date = moment('2011-04-15', 'YYYY-MM-DD');
date.range('month');
```
instead of typical use case:
```js
var start = moment('2017-01-01');
var end = moment('2017-01-05');
moment.range(start, end);
```

Performance tests (huge improvement):
https://jsperf.com/moment-range-constructor-performance/1