### PR TITLE
Add support for ISO start+duration and duration+end

### DIFF
--- a/lib/moment-range.js
+++ b/lib/moment-range.js
@@ -405,16 +405,19 @@ export function extendMoment(moment) {
    */
   moment.rangeFromISOString = function(isoTimeInterval) {
     const momentStrings = isoSplit(isoTimeInterval);
-    let start, end;
+    let start;
+    let end;
     if (momentStrings[0].startsWith('P')) {
       const d = moment.duration(momentStrings[0]);
       end = moment.parseZone(momentStrings[1]);
       start = end.clone().subtract(d);
-    } else if (momentStrings[1].startsWith('P')) {
+    }
+    else if (momentStrings[1].startsWith('P')) {
       const d = moment.duration(momentStrings[1]);
       start = moment.parseZone(momentStrings[0]);
       end = start.clone().add(d);
-    } else {
+    }
+    else {
       start = moment.parseZone(momentStrings[0]);
       end = moment.parseZone(momentStrings[1]);
     }

--- a/lib/moment-range.js
+++ b/lib/moment-range.js
@@ -405,8 +405,19 @@ export function extendMoment(moment) {
    */
   moment.rangeFromISOString = function(isoTimeInterval) {
     const momentStrings = isoSplit(isoTimeInterval);
-    const start = moment.parseZone(momentStrings[0]);
-    const end = moment.parseZone(momentStrings[1]);
+    let start, end;
+    if (momentStrings[0].startsWith('P')) {
+      const d = moment.duration(momentStrings[0]);
+      end = moment.parseZone(momentStrings[1]);
+      start = end.clone().subtract(d);
+    } else if (momentStrings[1].startsWith('P')) {
+      const d = moment.duration(momentStrings[1]);
+      start = moment.parseZone(momentStrings[0]);
+      end = start.clone().add(d);
+    } else {
+      start = moment.parseZone(momentStrings[0]);
+      end = moment.parseZone(momentStrings[1]);
+    }
     return new DateRange(start, end);
   };
 

--- a/lib/tests/moment-range.test.js
+++ b/lib/tests/moment-range.test.js
@@ -114,6 +114,26 @@ describe('DateRange', function() {
       expect(range.toString()).equal(timeInterval);
     });
 
+    it('should allow time intervals start/duration', function() {
+      const start = '2014-04-04T04:04:04Z';
+      const end   = '2015-05-05T05:05:05Z';
+      const duration   = 'P1Y1M1DT1H1M1S';
+      const timeInterval = start + '/' + duration;
+      const timeIntervalPlain = start + '/' + end;
+      const range = moment.rangeFromISOString(timeInterval);
+      expect(range.toString()).equal(timeIntervalPlain);
+    });
+
+    it('should allow ISO time intervals duration/end', function() {
+      const start = '2014-04-04T04:04:04Z';
+      const end   = '2015-05-05T05:05:05Z';
+      const duration   = 'P1Y1M1DT1H1M1S';
+      const timeInterval = duration + '/' + end;
+      const timeIntervalPlain = start + '/' + end;
+      const range = moment.rangeFromISOString(timeInterval);
+      expect(range.toString()).equal(timeIntervalPlain);
+    });
+
     it('should allow initialization with an array', function() {
       const dr = moment.range([m1, m2]);
 
@@ -716,6 +736,17 @@ describe('DateRange', function() {
       const acc1 = Array.from(dr1.reverseByRange(dr2, { excludeStart: true })).map(m => m.utc().format('YYYY-MM-DD'));
       const acc2 = Array.from(dr1.reverseByRange(dr2, { exclusive: true })).map(m => m.utc().format('YYYY-MM-DD'));
       expect(acc2).to.eql(acc1);
+    });
+
+    it('should iterate correctly by duration from ISO duration', function() {
+      const dr1 = moment.rangeFromISOString('P4Y/2014-04-04T00:00:00.000Z');
+      const dr2 = moment.duration(1, 'year');
+
+      const acc = Array.from(dr1.reverseByRange(dr2));
+
+      expect(acc.length).to.eql(5);
+      expect(acc[0].year()).to.eql(2014);
+      expect(acc[4].minute()).to.eql(2010);
     });
   });
 

--- a/typing-tests/flow/moment-range.test.js
+++ b/typing-tests/flow/moment-range.test.js
@@ -25,6 +25,8 @@ moment.rangeFromInterval('day', 3);
 moment.rangeFromInterval('day', 3, moment());
 
 moment.rangeFromISOString('2015-01-17T09:50:04+03:00/2015-04-17T08:29:55-04:00');
+moment.rangeFromISOString('2007-03-01T13:00:00Z/P1Y2M10DT2H30M');
+moment.rangeFromISOString('P1Y2M10DT2H30M/2008-05-11T15:30:00Z');
 moment.parseZoneRange('2015-01-17T09:50:04+03:00/2015-04-17T08:29:55-04:00'); // DEPRECATED 4.0.0
 
 moment().isRange(moment.range('hour'));

--- a/typing-tests/typescript/moment-range.test.ts
+++ b/typing-tests/typescript/moment-range.test.ts
@@ -24,6 +24,8 @@ moment.rangeFromInterval('day', 3);
 moment.rangeFromInterval('day', 3, moment());
 
 moment.rangeFromISOString('2015-01-17T09:50:04+03:00/2015-04-17T08:29:55-04:00');
+moment.rangeFromISOString('2007-03-01T13:00:00Z/P1Y2M10DT2H30M');
+moment.rangeFromISOString('P1Y2M10DT2H30M/2008-05-11T15:30:00Z');
 moment.parseZoneRange('2015-01-17T09:50:04+03:00/2015-04-17T08:29:55-04:00'); // DEPRECATED 4.0.0
 
 moment().isRange(moment.range('hour'));


### PR DESCRIPTION
[Wikipedia article](https://en.wikipedia.org/wiki/ISO_8601#Time_intervals) says:

> There are four ways to express a time interval:
>  1. Start and end, such as "2007-03-01T13:00:00Z/2008-05-11T15:30:00Z"
>  2. Start and duration, such as "2007-03-01T13:00:00Z/P1Y2M10DT2H30M"
>  3. Duration and end, such as "P1Y2M10DT2H30M/2008-05-11T15:30:00Z"
>  4. Duration only, such as "P1Y2M10DT2H30M", with additional context information

In this pull request I add support for cases 2 and 3 for the rangeFromISOString function.
To my undestanding case 4 is not meant to be supported in this library and case 1 is already supported in this library.