### PR TITLE
Correct ES6 import in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,10 @@ npm install --save moment-range
 **ES6:**
 
 ``` js
-import Moment from 'moment';
-import { extendMoment } from 'moment-range';
+import Moment from 'moment'
+import MomentRange from 'moment-range'
 
-const moment = extendMoment(Moment);
+const moment = MomentRange.extendMoment(Moment);
 ```
 
 **TypeScript:**


### PR DESCRIPTION
Correction of the error : 'extendMoment' is not exported by node_modules/moment-range/dist/moment-range.js