### PR TITLE
Added overload for default export to extendMoment

### DIFF
--- a/lib/moment-range.d.ts
+++ b/lib/moment-range.d.ts
@@ -1,5 +1,5 @@
-import * as moment from 'moment';
-import {Moment, unitOfTime} from 'moment';
+import * as momentNs from 'moment';
+import moment, {Moment, unitOfTime} from 'moment';
 
 export class DateRange {
   start: Moment;
@@ -86,4 +86,5 @@ declare module 'moment' {
   }
 }
 
+export function extendMoment(momentClass: typeof momentNs): MomentRange & typeof momentNs;
 export function extendMoment(momentClass: typeof moment): MomentRange & typeof moment;

--- a/typing-tests/typescript/tsconfig.json
+++ b/typing-tests/typescript/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compileOnSave": false,
   "compilerOptions": {
-    "allowSyntheticDefaultImports": false,
+    "allowSyntheticDefaultImports": true,
     "baseUrl": ".",
     "declaration": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
Allows passing the `moment` constructor function to extendMoment imported like follows: `import moment from 'moment';` as an alternative to `import * as moment from 'moment';` (which doesn't allow to construct a moment instance).
Changing `allowSyntheticDefaultImports` to `true` is actually reccomended by the Moment docs found [here](https://momentjs.com/docs/#/use-it/typescript/).