### PR TITLE
Correcting `isRange` typing

### DIFF
--- a/lib/moment-range.d.ts
+++ b/lib/moment-range.d.ts
@@ -72,6 +72,8 @@ export interface MomentRangeStaticMethods {
 
   // @deprecated 4.0.0
   parseZoneRange(isoTimeInterval: string): DateRange;
+
+  isRange(range: any): boolean;
 }
 
 export interface MomentRange extends MomentRangeStaticMethods {
@@ -80,8 +82,6 @@ export interface MomentRange extends MomentRangeStaticMethods {
 
 declare module 'moment' {
   export interface Moment {
-    isRange(range: any): boolean;
-
     within(range: DateRange): boolean;
   }
 }


### PR DESCRIPTION
Corrects `isRange` typing to match the JavaScript use and documentation.

	moment.isRange(range); // true
	moment.isRange(IamNotRange); // false